### PR TITLE
Set minimum requirements instead of fixed requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cobamp"
-version = "0.1.0"
+version = "0.2.2"
 description = "Constraint-based modeling framework for the enumeration of pathway analysis concepts"
 authors = [
     {name = "Jorge Ferreira", email = "jorge.ferreira@ceb.uminho.pt"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,12 @@
 name = "cobamp"
 version = "0.1.0"
 description = "Constraint-based modeling framework for the enumeration of pathway analysis concepts"
+authors = [
+    {name = "Jorge Ferreira", email = "jorge.ferreira@ceb.uminho.pt"},
+    {name = "Vítor Vieira"}
+]
 readme = "README.rst"
+license = {file = "LICENSE.txt"}
 requires-python = ">=3.10"
 dependencies = [
     "boolean-py>=3.8",
@@ -14,3 +19,21 @@ dependencies = [
     "pathos>=0.2.9",
     "scipy>=1.7.3",
 ]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3.6",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Topic :: Software Development :: Libraries :: Python Modules"
+]
+
+[project.urls]
+Repository = "https://github.com/BioSystemsUM/cobamp"
+Homepage = "https://github.com/BioSystemsUM/cobamp"
+Documentation = "http://cobamp.readthedocs.io/"
+Issues = "https://github.com/BioSystemsUM/cobamp/issues"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "cobamp"
+version = "0.1.0"
+description = "Constraint-based modeling framework for the enumeration of pathway analysis concepts"
+readme = "README.rst"
+requires-python = ">=3.10"
+dependencies = [
+    "boolean-py>=3.8",
+    "indexed>=1.2.1",
+    "matplotlib>=3.5.2",
+    "numpy>=1.21.6",
+    "optlang>=1.5.2",
+    "pandas>=1.3.5",
+    "pathos>=0.2.9",
+    "scipy>=1.7.3",
+]


### PR DESCRIPTION
The current implementation (`requirements.txt`) has fixed dependency versions. This makes it impossible to update to newer packages if Cobamp is also required. This pull request loosens the fixes requirements and instead uses minimum requirements

This isn't a perfect fix (ideally, a maximum version would be included as well), but I could not get the tests to work properly to determine what maximum versions for each dependency should be set to.